### PR TITLE
Fix backend for Pydantic v2 and SQLAlchemy metadata conflicts

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, UploadFile, File, BackgroundTasks, Depends, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from schemas import UploadResponse, StatusResponse, UploadRequest
+from schemas import UploadResponse, TaskStatus, UploadRequest
 from tasks import process_meeting_upload
 from db import init_db, get_task_status
 import aiofiles
@@ -34,11 +34,11 @@ async def save_temp(file: UploadFile) -> str:
 
 @app.post("/api/upload", response_model=UploadResponse)
 async def upload(
+    background: BackgroundTasks,
     file: UploadFile = File(...),
     title: Optional[str] = None,
     meeting_type: Optional[str] = "general",
     attendees: Optional[str] = None,
-    background: BackgroundTasks = Depends()
 ):
     """Upload audio file for processing"""
     try:
@@ -63,13 +63,13 @@ async def upload(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Upload failed: {str(e)}")
 
-@app.get("/api/status/{task_id}", response_model=StatusResponse)
+@app.get("/api/status/{task_id}", response_model=TaskStatus)
 def status(task_id: str):
     """Get task status"""
     status_data = get_task_status(task_id)
     if not status_data:
         raise HTTPException(status_code=404, detail="Task not found")
-    return StatusResponse(**status_data)
+    return TaskStatus(**status_data)
 
 @app.get("/")
 def read_root():

--- a/backend/db.py
+++ b/backend/db.py
@@ -86,19 +86,19 @@ def init_db():
     # Apply SQLite-specific optimizations
     with engine.connect() as conn:
         # Enable Write-Ahead Logging for better concurrent access
-        conn.execute("PRAGMA journal_mode=WAL")
-        
+        conn.exec_driver_sql("PRAGMA journal_mode=WAL")
+
         # Increase cache size to 64MB for better performance
-        conn.execute("PRAGMA cache_size=-64000")
-        
+        conn.exec_driver_sql("PRAGMA cache_size=-64000")
+
         # Enable foreign key constraints
-        conn.execute("PRAGMA foreign_keys=ON")
-        
+        conn.exec_driver_sql("PRAGMA foreign_keys=ON")
+
         # Set synchronous mode to NORMAL for balance of safety and performance
-        conn.execute("PRAGMA synchronous=NORMAL")
-        
+        conn.exec_driver_sql("PRAGMA synchronous=NORMAL")
+
         # Set busy timeout to handle concurrent access
-        conn.execute("PRAGMA busy_timeout=30000")
+        conn.exec_driver_sql("PRAGMA busy_timeout=30000")
     
     print("✅ Database initialized successfully with optimizations")
 
@@ -262,7 +262,7 @@ def save_meeting_insights(meeting_id: int, insights: Dict[str, Any]):
                 meeting_id=meeting_id,
                 type="action_item",
                 content=item["text"],
-                metadata=json.dumps({
+                metadata_json=json.dumps({
                     "assignee": item.get("assignee"),
                     "due_date": item.get("due_date"),
                     "priority": item.get("priority", "medium")
@@ -277,7 +277,7 @@ def save_meeting_insights(meeting_id: int, insights: Dict[str, Any]):
                 meeting_id=meeting_id,
                 type="decision",
                 content=decision["text"],
-                metadata=json.dumps({
+                metadata_json=json.dumps({
                     "impact": decision.get("impact", "medium"),
                     "rationale": decision.get("rationale")
                 }),
@@ -292,7 +292,7 @@ def save_meeting_insights(meeting_id: int, insights: Dict[str, Any]):
                 meeting_id=meeting_id,
                 type="sentiment",
                 content=f"Overall sentiment: {sentiment['overall']}",
-                metadata=json.dumps({
+                metadata_json=json.dumps({
                     "score": sentiment["score"],
                     "positive_ratio": sentiment.get("positive_ratio", 0.0),
                     "negative_ratio": sentiment.get("negative_ratio", 0.0)

--- a/backend/models.py
+++ b/backend/models.py
@@ -108,7 +108,7 @@ class Task(Base, TimestampMixin):
     )
     
     # Processing metadata
-    metadata = Column(
+    task_metadata = Column(
         JSON,
         nullable=True,
         comment="Additional task metadata (file info, settings, etc.)"
@@ -610,7 +610,7 @@ class Insight(Base, TimestampMixin):
     )
     
     # Structured metadata for different insight types
-    metadata = Column(
+    metadata_json = Column(
         JSON,
         nullable=True,
         comment="Type-specific structured data as JSON"
@@ -690,16 +690,16 @@ class Insight(Base, TimestampMixin):
     
     def get_metadata_value(self, key: str, default=None):
         """Get a specific value from metadata JSON"""
-        if self.metadata and isinstance(self.metadata, dict):
-            return self.metadata.get(key, default)
+        if self.metadata_json and isinstance(self.metadata_json, dict):
+            return self.metadata_json.get(key, default)
         return default
-    
+
     def set_metadata_value(self, key: str, value):
         """Set a specific value in metadata JSON"""
-        if not self.metadata:
-            self.metadata = {}
-        if isinstance(self.metadata, dict):
-            self.metadata[key] = value
+        if not self.metadata_json:
+            self.metadata_json = {}
+        if isinstance(self.metadata_json, dict):
+            self.metadata_json[key] = value
     
     def to_dict(self) -> Dict[str, Any]:
         """Convert model to dictionary for JSON serialization"""
@@ -709,7 +709,7 @@ class Insight(Base, TimestampMixin):
             'type': self.type,
             'content': self.content,
             'confidence': self.confidence,
-            'metadata': self.metadata,
+            'metadata': self.metadata_json,
             'source_segment_id': self.source_segment_id,
             'priority': self.priority,
             'status': self.status,

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,7 +4,7 @@ celery==5.3.4
 redis==5.0.1
 sqlalchemy==2.0.23
 python-multipart==0.0.6
-pydantic==1.10.12
+pydantic>=2.7,<3.0
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 python-dotenv==1.0.0

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -14,7 +14,7 @@ Key Features:
 """
 
 from pydantic import BaseModel, Field, validator, root_validator
-from typing import Optional, List, Dict, Any, Union
+from typing import Optional, List, Dict, Any, Union, Literal
 from datetime import datetime
 from enum import Enum
 import re
@@ -243,17 +243,20 @@ class ActionItemInsight(InsightBase):
     Specialized schema for action item insights.
     Includes assignee, due date, and priority information.
     """
-    type: InsightType = Field(default=InsightType.ACTION_ITEM, const=True)
+    type: Literal[InsightType.ACTION_ITEM] = Field(
+        default=InsightType.ACTION_ITEM,
+        description="Insight type"
+    )
     assignee: Optional[str] = Field(default=None, description="Person assigned to the task")
     due_date: Optional[datetime] = Field(default=None, description="Task due date")
     priority: str = Field(
         default="medium",
-        regex="^(low|medium|high|urgent)$",
+        pattern="^(low|medium|high|urgent)$",
         description="Task priority level"
     )
     status: str = Field(
         default="open",
-        regex="^(open|in_progress|completed|cancelled)$",
+        pattern="^(open|in_progress|completed|cancelled)$",
         description="Current task status"
     )
 
@@ -262,10 +265,13 @@ class DecisionInsight(InsightBase):
     Specialized schema for decision insights.
     Includes impact level and rationale.
     """
-    type: InsightType = Field(default=InsightType.DECISION, const=True)
+    type: Literal[InsightType.DECISION] = Field(
+        default=InsightType.DECISION,
+        description="Insight type"
+    )
     impact: str = Field(
         default="medium",
-        regex="^(low|medium|high|critical)$",
+        pattern="^(low|medium|high|critical)$",
         description="Decision impact level"
     )
     rationale: Optional[str] = Field(default=None, description="Decision reasoning")
@@ -350,7 +356,7 @@ class SearchRequest(BaseSchema):
     # Search options
     search_type: str = Field(
         default="hybrid",
-        regex="^(text|semantic|hybrid)$",
+        pattern="^(text|semantic|hybrid)$",
         description="Type of search to perform"
     )
     
@@ -425,7 +431,7 @@ class SearchResult(BaseSchema):
     # Match information
     match_type: str = Field(
         ...,
-        regex="^(title|content|insight)$",
+        pattern="^(title|content|insight)$",
         description="Where the match was found"
     )
     
@@ -479,7 +485,7 @@ class MeetingAnalytics(BaseSchema):
     # Sentiment analysis
     overall_sentiment: Optional[str] = Field(
         default=None,
-        regex="^(positive|neutral|negative)$",
+        pattern="^(positive|neutral|negative)$",
         description="Overall meeting sentiment"
     )
     sentiment_score: Optional[float] = Field(
@@ -503,7 +509,7 @@ class SystemHealth(BaseSchema):
     """
     status: str = Field(
         ...,
-        regex="^(healthy|degraded|unhealthy)$",
+        pattern="^(healthy|degraded|unhealthy)$",
         description="Overall system status"
     )
     


### PR DESCRIPTION
## Summary
- update Pydantic schemas and imports for v2, replacing deprecated `const`/`regex` usage
- rename reserved SQLAlchemy `metadata` columns and adjust task status API
- use `exec_driver_sql` for SQLite PRAGMA setup and remove invalid dependency injection

## Testing
- `pytest -q`
- `uvicorn app:app --port 8000 --host 0.0.0.0`

------
https://chatgpt.com/codex/tasks/task_e_688ee130af94832bba7211c2d6a51782