### PR TITLE
Fix backend container command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -369,9 +369,9 @@ services:
     
     networks:
       - meeting-intelligence
-    
+
     # Development command with auto-reload
-    command: ["uvicorn", "backend.app:app", "--host", "0.0.0.0", "--port", "8000"]
+    command: ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]
 
   # Celery Worker - Background task processing
   celery-worker:


### PR DESCRIPTION
## Summary
- fix: correct backend uvicorn module path to `app:app`

## Testing
- `python -m py_compile backend/*.py`
- `python - <<'PY'
import yaml
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('docker-compose.yml is valid YAML')
PY`


------
https://chatgpt.com/codex/tasks/task_e_688ef6778444832bbb44099f36d86588