### PR TITLE
Fix backend container startup by mounting project root

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -344,7 +344,7 @@ services:
     
     volumes:
       # Source code mounting for development hot-reload
-      - ./backend:/app
+      - .:/app
       # Media storage for uploaded files
       - media_storage:/app/media
       # Python package cache
@@ -395,7 +395,7 @@ services:
       - LOG_LEVEL=INFO
     
     volumes:
-      - ./backend:/app
+      - .:/app
       - media_storage:/app/media
     
     # Dependencies
@@ -411,7 +411,7 @@ services:
       - meeting-intelligence
     
     # Celery worker command with concurrency
-    command: ["celery", "-A", "celery_config.celery_app", "worker", "--loglevel=info", "--concurrency=4"]
+    command: ["celery", "-A", "backend.celery_config.celery_app", "worker", "--loglevel=info", "--concurrency=4"]
     
     # Resource allocation for background processing
     deploy:
@@ -510,7 +510,7 @@ services:
       - CELERY_RESULT_BACKEND=redis://redis:6379/0
     
     volumes:
-      - ./backend:/app
+      - .:/app
     
     depends_on:
       redis:
@@ -522,7 +522,7 @@ services:
       - meeting-intelligence
     
     # Celery beat command for periodic tasks
-    command: ["celery", "-A", "celery_config.celery_app", "beat", "--loglevel=info"]
+    command: ["celery", "-A", "backend.celery_config.celery_app", "beat", "--loglevel=info"]
     
     # Only start with monitoring profile
     profiles:
@@ -550,9 +550,12 @@ services:
     
     networks:
       - meeting-intelligence
+
+    volumes:
+      - .:/app
     
     # Flower monitoring command
-    command: ["celery", "-A", "celery_config.celery_app", "flower", "--port=5555"]
+    command: ["celery", "-A", "backend.celery_config.celery_app", "flower", "--port=5555"]
     
     # Only start with monitoring profile
     profiles:


### PR DESCRIPTION
## Summary
- Mount entire project root in backend and Celery services
- Reference Celery configuration via `backend.celery_config.celery_app`

## Testing
- `python -m py_compile backend/app.py backend/celery_config.py backend/db.py backend/models.py backend/schemas.py backend/tasks.py`
- `python -m uvicorn backend.app:app --host 127.0.0.1 --port 8000`
- `python - <<'PY'
import yaml,sys
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('docker-compose.yml valid')
PY`


------
https://chatgpt.com/codex/tasks/task_e_688ef6778444832bbb44099f36d86588