### PR TITLE
fix upload api base url

### DIFF
--- a/frontend/src/app/upload/upload.component.ts
+++ b/frontend/src/app/upload/upload.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';  // Angular core
+import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-upload',
@@ -47,7 +48,8 @@ export class UploadComponent {
     const form = new FormData();
     form.append('file', file);             // append to form
     
-    fetch('/api/upload', {                 // POST to backend
+    const uploadUrl = `${environment.apiBaseUrl}/upload`;
+    fetch(uploadUrl, {                     // POST to backend
       method: 'POST',
       body: form
     })
@@ -79,7 +81,8 @@ export class UploadComponent {
 
   pollStatus() {
     if (!this.taskId) return;
-    fetch(`/api/status/${this.taskId}`)     // GET status
+    const statusUrl = `${environment.apiBaseUrl}/status/${this.taskId}`;
+    fetch(statusUrl)                       // GET status
       .then(res => res.json())
       .then(s => this.progress = s.percent) // update progress
       .catch(() => {});                     // ignore errors

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,6 +1,6 @@
 export const environment = {
   production: false,
-  apiBaseUrl: 'http://localhost:8000',
-  wsBaseUrl: 'ws://localhost:8000',
+  apiBaseUrl: 'http://localhost:8080/api',
+  wsBaseUrl: 'ws://localhost:8080',
   version: '1.0.0'
 }; 


### PR DESCRIPTION
## Summary
- ensure upload component uses environment-configured API URLs for upload and status polling
- point development environment to backend at port 8080

## Testing
- `node node_modules/@angular/cli/bin/ng lint` *(fails: Cannot find "lint" target)*
- `node node_modules/@angular/cli/bin/ng test --watch=false` *(fails: detected Angular version 16.2.12, but @angular/build supports ^20.0.0)*
- `node node_modules/@angular/cli/bin/ng build` *(fails: detected Angular version 16.2.12, but @angular/build supports ^20.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_689000fe5400832bb25da7e735da75f6